### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,132 +1,136 @@
 # Zendesk API MCP Server
 
-    A comprehensive Model Context Protocol (MCP) server for interacting with the Zendesk API. This server provides tools and resources for managing Zendesk Support, Talk, Chat, and Guide products.
+A comprehensive Model Context Protocol (MCP) server for interacting with the Zendesk API. This server provides tools and resources for managing Zendesk Support, Talk, Chat, and Guide products.
 
-    ## Features
+<a href="https://glama.ai/mcp/servers/@JurreBrandsenInfoSupport/zendesk-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@JurreBrandsenInfoSupport/zendesk-mcp/badge" alt="Zendesk API Server MCP server" />
+</a>
 
-    - Complete coverage of Zendesk API functionality
-    - Tools for managing tickets, users, organizations, and more
-    - Resources for accessing Zendesk API documentation
-    - Secure authentication with Zendesk API tokens
+## Features
 
-    ## Getting Started
+- Complete coverage of Zendesk API functionality
+- Tools for managing tickets, users, organizations, and more
+- Resources for accessing Zendesk API documentation
+- Secure authentication with Zendesk API tokens
 
-    ### Prerequisites
+## Getting Started
 
-    - Node.js 14 or higher
-    - A Zendesk account with API access
+### Prerequisites
 
-    ### Installation
+- Node.js 14 or higher
+- A Zendesk account with API access
 
-    1. Clone this repository
-    2. Install dependencies:
-       ```
-       npm install
-       ```
-    3. Create a `.env` file with your Zendesk credentials:
-       ```
-       ZENDESK_SUBDOMAIN=your-subdomain
-       ZENDESK_EMAIL=your-email@example.com
-       ZENDESK_API_TOKEN=your-api-token
-       ```
+### Installation
 
-    ### Running the Server
+1. Clone this repository
+2. Install dependencies:
+   ```
+   npm install
+   ```
+3. Create a `.env` file with your Zendesk credentials:
+   ```
+   ZENDESK_SUBDOMAIN=your-subdomain
+   ZENDESK_EMAIL=your-email@example.com
+   ZENDESK_API_TOKEN=your-api-token
+   ```
 
-    Start the server:
-    ```
-    npm start
-    ```
+### Running the Server
 
-    For development with auto-restart:
-    ```
-    npm run dev
-    ```
+Start the server:
+```
+npm start
+```
 
-    ### Testing with MCP Inspector
+For development with auto-restart:
+```
+npm run dev
+```
 
-    Test the server using the MCP Inspector:
-    ```
-    npm run inspect
-    ```
+### Testing with MCP Inspector
 
-    ## Available Tools
+Test the server using the MCP Inspector:
+```
+npm run inspect
+```
 
-    ### Tickets
-    - `list_tickets`: List tickets in Zendesk
-    - `get_ticket`: Get a specific ticket by ID
-    - `create_ticket`: Create a new ticket
-    - `update_ticket`: Update an existing ticket
-    - `delete_ticket`: Delete a ticket
+## Available Tools
 
-    ### Users
-    - `list_users`: List users in Zendesk
-    - `get_user`: Get a specific user by ID
-    - `create_user`: Create a new user
-    - `update_user`: Update an existing user
-    - `delete_user`: Delete a user
+### Tickets
+- `list_tickets`: List tickets in Zendesk
+- `get_ticket`: Get a specific ticket by ID
+- `create_ticket`: Create a new ticket
+- `update_ticket`: Update an existing ticket
+- `delete_ticket`: Delete a ticket
 
-    ### Organizations
-    - `list_organizations`: List organizations in Zendesk
-    - `get_organization`: Get a specific organization by ID
-    - `create_organization`: Create a new organization
-    - `update_organization`: Update an existing organization
-    - `delete_organization`: Delete an organization
+### Users
+- `list_users`: List users in Zendesk
+- `get_user`: Get a specific user by ID
+- `create_user`: Create a new user
+- `update_user`: Update an existing user
+- `delete_user`: Delete a user
 
-    ### Groups
-    - `list_groups`: List agent groups in Zendesk
-    - `get_group`: Get a specific group by ID
-    - `create_group`: Create a new agent group
-    - `update_group`: Update an existing group
-    - `delete_group`: Delete a group
+### Organizations
+- `list_organizations`: List organizations in Zendesk
+- `get_organization`: Get a specific organization by ID
+- `create_organization`: Create a new organization
+- `update_organization`: Update an existing organization
+- `delete_organization`: Delete an organization
 
-    ### Macros
-    - `list_macros`: List macros in Zendesk
-    - `get_macro`: Get a specific macro by ID
-    - `create_macro`: Create a new macro
-    - `update_macro`: Update an existing macro
-    - `delete_macro`: Delete a macro
+### Groups
+- `list_groups`: List agent groups in Zendesk
+- `get_group`: Get a specific group by ID
+- `create_group`: Create a new agent group
+- `update_group`: Update an existing group
+- `delete_group`: Delete a group
 
-    ### Views
-    - `list_views`: List views in Zendesk
-    - `get_view`: Get a specific view by ID
-    - `create_view`: Create a new view
-    - `update_view`: Update an existing view
-    - `delete_view`: Delete a view
+### Macros
+- `list_macros`: List macros in Zendesk
+- `get_macro`: Get a specific macro by ID
+- `create_macro`: Create a new macro
+- `update_macro`: Update an existing macro
+- `delete_macro`: Delete a macro
 
-    ### Triggers
-    - `list_triggers`: List triggers in Zendesk
-    - `get_trigger`: Get a specific trigger by ID
-    - `create_trigger`: Create a new trigger
-    - `update_trigger`: Update an existing trigger
-    - `delete_trigger`: Delete a trigger
+### Views
+- `list_views`: List views in Zendesk
+- `get_view`: Get a specific view by ID
+- `create_view`: Create a new view
+- `update_view`: Update an existing view
+- `delete_view`: Delete a view
 
-    ### Automations
-    - `list_automations`: List automations in Zendesk
-    - `get_automation`: Get a specific automation by ID
-    - `create_automation`: Create a new automation
-    - `update_automation`: Update an existing automation
-    - `delete_automation`: Delete an automation
+### Triggers
+- `list_triggers`: List triggers in Zendesk
+- `get_trigger`: Get a specific trigger by ID
+- `create_trigger`: Create a new trigger
+- `update_trigger`: Update an existing trigger
+- `delete_trigger`: Delete a trigger
 
-    ### Search
-    - `search`: Search across Zendesk data
+### Automations
+- `list_automations`: List automations in Zendesk
+- `get_automation`: Get a specific automation by ID
+- `create_automation`: Create a new automation
+- `update_automation`: Update an existing automation
+- `delete_automation`: Delete an automation
 
-    ### Help Center
-    - `list_articles`: List Help Center articles
-    - `get_article`: Get a specific Help Center article by ID
-    - `create_article`: Create a new Help Center article
-    - `update_article`: Update an existing Help Center article
-    - `delete_article`: Delete a Help Center article
+### Search
+- `search`: Search across Zendesk data
 
-    ### Talk
-    - `get_talk_stats`: Get Zendesk Talk statistics
+### Help Center
+- `list_articles`: List Help Center articles
+- `get_article`: Get a specific Help Center article by ID
+- `create_article`: Create a new Help Center article
+- `update_article`: Update an existing Help Center article
+- `delete_article`: Delete a Help Center article
 
-    ### Chat
-    - `list_chats`: List Zendesk Chat conversations
+### Talk
+- `get_talk_stats`: Get Zendesk Talk statistics
 
-    ## Available Resources
+### Chat
+- `list_chats`: List Zendesk Chat conversations
 
-    - `zendesk://docs/{section}`: Access documentation for different sections of the Zendesk API
+## Available Resources
 
-    ## License
+- `zendesk://docs/{section}`: Access documentation for different sections of the Zendesk API
 
-    MIT
+## License
+
+MIT


### PR DESCRIPTION
This PR adds a badge for the [Zendesk API MCP Server](https://glama.ai/mcp/servers/@JurreBrandsenInfoSupport/zendesk-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@JurreBrandsenInfoSupport/zendesk-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@JurreBrandsenInfoSupport/zendesk-mcp/badge" alt="Zendesk API Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.